### PR TITLE
Skip of absent & difference between group and individual consultations

### DIFF
--- a/src/components/embed_pages/TeachersQueryQueueEmbedPage.ts
+++ b/src/components/embed_pages/TeachersQueryQueueEmbedPage.ts
@@ -5,7 +5,7 @@ export const data = new EmbedPage(
     client,
     'teachers',
     'Cola de espera de consultas',
-    'Para consultas por vos',
+    'Si querés atender la próxima consulta, presioná el botón `Atender Próximo Grupo`, si ves que la cola de espera quedó con consultas, podés limpiarla con el botón `Limpiar',
     [client.config.teachersQueryChannelID],
     client.queryQueue.toEmbedFieldData(),
     ['dequeue']

--- a/src/components/models/QueryQueue.ts
+++ b/src/components/models/QueryQueue.ts
@@ -68,17 +68,10 @@ export class QueryQueue {
                 const group = member.roles.cache.find((role) =>
                     role.name.startsWith('Grupo')
                 );
-                if (group) {
-                    queryQueueData.push({
-                        name: `#${i + 1} ${member.displayName}`,
-                        value: `${group.name}`,
-                    });
-                } else {
-                    queryQueueData.push({
-                        name: `#${i} ${member}`,
-                        value: `Sin grupo`,
-                    });
-                }
+                queryQueueData.push({
+                    name: `#${i + 1} ${member.displayName}`,
+                    value: `${group ? group.name : `Sin grupo`}`,
+                });
             }
         }
 


### PR DESCRIPTION
- La interacción con el botón de `Atender siguiente` ahora diferencia entre consultas de grupo e individuales
- Además saltea las consultas de personas que las realizaron y abandonaron su canal de voz.
- Debería borrarse de la cola automáticamente la consulta de un grupo/individual cuando se desintegra el canal de voz (porque el grupo o individuo abandonó el canal de voz)?
- Debería haber un botón de `Limpiar` para el chat de texto docente?