### PR TITLE
Fix #17

### DIFF
--- a/src/components/buttons/QueueQueryButton.ts
+++ b/src/components/buttons/QueueQueryButton.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, GuildMember, MessageButton } from 'discord.js';
+import { ButtonInteraction, GuildMember, MessageButton, TextChannel } from 'discord.js';
 import { client } from '../../index';
 
 export const execute = async (interaction: ButtonInteraction) => {
@@ -37,6 +37,9 @@ export const execute = async (interaction: ButtonInteraction) => {
         content: 'Has sido puesto en la cola de espera!',
         ephemeral: true,
     });
+
+    const teachersTextChannel = interaction.guild?.channels.cache.find((channel) => channel.id === client.config.teachersTextChannelID) as TextChannel;
+    await teachersTextChannel!.send(`${member.displayName}(${group ? group.name : 'sin grupo'}) necesita ayuda en un canal de voz`);
 };
 
 export const data = new MessageButton()

--- a/src/components/embed_pages/ PapersEmbedPage.ts
+++ b/src/components/embed_pages/ PapersEmbedPage.ts
@@ -7,6 +7,7 @@ export const data = new EmbedPage(
     client,
     true,
     true,
+    false,
     'papers',
     'Lista de lecturas obligatorias',
     'Links a papers',

--- a/src/components/embed_pages/ClassInfoEmbedPage.ts
+++ b/src/components/embed_pages/ClassInfoEmbedPage.ts
@@ -6,6 +6,7 @@ export const data = new EmbedPage(
     client,
     false,
     false,
+    false,
     'nextClass',
     'Información de la próxima clase',
     '',

--- a/src/components/embed_pages/ReadmeEmbedPage.ts
+++ b/src/components/embed_pages/ReadmeEmbedPage.ts
@@ -5,6 +5,7 @@ export const data = new EmbedPage(
     client,
     true,
     true,
+    false,
     'readme',
     'Algoritmos y Programación III - Cátedra Leveroni',
     'Para consultas por vos',

--- a/src/components/embed_pages/StudentsEmbedPage.ts
+++ b/src/components/embed_pages/StudentsEmbedPage.ts
@@ -5,6 +5,7 @@ export const data = new EmbedPage(
     client,
     true,
     true,
+    false,
     'students',
     'Cola de espera de consultas',
     'Si tenes una duda y te gustaría que un profesor visite el canal el canal de voz de tu grupo, presioná el botón de `Pedir Ayuda`. Si ya no necesitás la consulta, retirate de la fila con el botón de `Cancelar Consulta`, así le das tu lugar al siguiente en espera.',

--- a/src/components/embed_pages/TeachersQueryQueueEmbedPage.ts
+++ b/src/components/embed_pages/TeachersQueryQueueEmbedPage.ts
@@ -4,6 +4,7 @@ import { client } from '../../index';
 export const data = new EmbedPage(
     client,
     true,
+    false,
     true,
     'teachers',
     'Cola de espera de consultas',

--- a/src/components/models/EmbedPage.ts
+++ b/src/components/models/EmbedPage.ts
@@ -21,11 +21,13 @@ export class EmbedPage {
     public content: string | null;
     public autoSend: boolean;
     public edit: boolean;
+    public cleanChatHistory: boolean;
 
     constructor(
         client: AlgoBot,
         autoSend: boolean,
         edit: boolean,
+        cleanChatHistory: boolean,
         name: string,
         title: string,
         description: string = '',
@@ -40,6 +42,7 @@ export class EmbedPage {
         this.content = content;
         this.autoSend = autoSend;
         this.edit = edit;
+        this.cleanChatHistory = cleanChatHistory;
         this.targetChannels = this.channelsFromIDs(targetChannelsIDs);
         this.data = this.buildData(title, description, fieldsData, url);
         this.components = this.buildComponents(buttons);
@@ -115,6 +118,9 @@ export class EmbedPage {
 
             if (this.targetChannelIsNotEmpty(previousMessages) && this.edit) {
                 await previousMessages.first()!.edit(messageContent);
+            } else if (this.targetChannelIsNotEmpty(previousMessages) && this.cleanChatHistory){
+                await previousMessages.first()!.delete();
+                await targetChannel.send(messageContent);
             } else {
                 await targetChannel.send(messageContent);
             }

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -17,4 +17,5 @@ export interface Config {
     devRoleID: string;
     devTextChannelID: string;
     generalTextChannelID: string;
+    teachersTextChannelID: string;
 }


### PR DESCRIPTION
# Cambios
- Se agrega flag `cleanChatHistory` si se quiere que una `EmbedPage` borre el mensaje anterior previo a ser enviada
- Se modifican las propiedades de `TeachersQueryQueueEmbed` para que antes de enviarse borre el mensaje anterior (en lugar de editarlo como era antes) y se envíe uno nuevo (para que llegue la notificación de que se envió un mensaje a ese canal)
- Se envía un mensaje al chat de docentes cada vez que un grupo/persona pide ayuda