### PR TITLE
[Feature] User Registration Command

### DIFF
--- a/src/commands/RequestDiscordAccessCommand.ts
+++ b/src/commands/RequestDiscordAccessCommand.ts
@@ -20,9 +20,15 @@ function padronIsValid(padron: string) {
 }
 
 function studentIsValid(email: string, padron: string): boolean {
-    return students.some((student) => {
-        return student.includes(email) && student.includes(padron);
-    });
+    for (const index in students) {
+        if (
+            students[index].includes(email) &&
+            students[index].includes(padron)
+        ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export const execute: ExecuteFunction = async (

--- a/src/commands/RequestDiscordAccessCommand.ts
+++ b/src/commands/RequestDiscordAccessCommand.ts
@@ -20,15 +20,9 @@ function padronIsValid(padron: string) {
 }
 
 function studentIsValid(email: string, padron: string): boolean {
-    for (const index in students) {
-        if (
-            students[index].includes(email) &&
-            students[index].includes(padron)
-        ) {
-            return true;
-        }
-    }
-    return false;
+    return (students as any[]).some((student) => (
+        student.includes(email) && student.includes(padron)
+    ));
 }
 
 export const execute: ExecuteFunction = async (

--- a/src/commands/RequestDiscordAccessCommand.ts
+++ b/src/commands/RequestDiscordAccessCommand.ts
@@ -19,16 +19,10 @@ function padronIsValid(padron: string) {
     );
 }
 
-function getStudentInfo(email: string, padron: string) {
-    for (const index in students) {
-        if (
-            students[index].includes(email) &&
-            students[index].includes(padron)
-        ) {
-            return students[index];
-        }
-    }
-    return [];
+function studentIsValid(email: string, padron: string): boolean {
+    return students.some((student) => {
+        return student.includes(email) && student.includes(padron);
+    });
 }
 
 export const execute: ExecuteFunction = async (
@@ -40,12 +34,10 @@ export const execute: ExecuteFunction = async (
 
     await interaction.deferReply({ ephemeral: true });
 
-    const studentInfo = getStudentInfo(email, padron);
-
     if (
         !emailIsValid(email) ||
         !padronIsValid(padron) ||
-        studentInfo.length === 0
+        !studentIsValid(email, padron)
     ) {
         await interaction.editReply(
             'Datos ingresados inválidos (revisá que estén bien escritos y recordá que tenés que utilizar los mismos usaste para llenar el forms). \n*Si llevás varios intentos, consultá con un docente...*'

--- a/src/commands/RequestDiscordAccessCommand.ts
+++ b/src/commands/RequestDiscordAccessCommand.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, GuildMember } from 'discord.js';
 import { ExecuteFunction } from '../interfaces/Command';
-import * as students from '../../assets/Listado.json';
+import students from '../../assets/Listado.json';
 
 function emailIsValid(email: string) {
     const re =

--- a/src/commands/RequestDiscordAccessCommand.ts
+++ b/src/commands/RequestDiscordAccessCommand.ts
@@ -1,0 +1,86 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction, GuildMember } from 'discord.js';
+import { ExecuteFunction } from '../interfaces/Command';
+import * as students from '../../assets/Listado.json';
+
+function emailIsValid(email: string) {
+    const re =
+        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(String(email).toLowerCase());
+}
+
+function padronIsValid(padron: string) {
+    const minimumPadronLength = 5;
+    const maximumPadronLength = 6;
+    return (
+        padron.length >= minimumPadronLength &&
+        padron.length <= maximumPadronLength &&
+        !isNaN(parseInt(padron))
+    );
+}
+
+function getStudentInfo(email: string, padron: string) {
+    for (const index in students) {
+        if (
+            students[index].includes(email) &&
+            students[index].includes(padron)
+        ) {
+            return students[index];
+        }
+    }
+    return [];
+}
+
+export const execute: ExecuteFunction = async (
+    interaction: CommandInteraction
+): Promise<void> => {
+    const email = interaction.options.data[0].value as string;
+    const padron = interaction.options.data[1].value as string;
+    const member = interaction.member as GuildMember;
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const studentInfo = getStudentInfo(email, padron);
+
+    if (
+        !emailIsValid(email) ||
+        !padronIsValid(padron) ||
+        studentInfo.length === 0
+    ) {
+        await interaction.editReply(
+            'Datos ingresados inválidos (revisá que estén bien escritos y recordá que tenés que utilizar los mismos usaste para llenar el forms). \n*Si llevás varios intentos, consultá con un docente...*'
+        );
+        return;
+    }
+
+    let cuatrimestre = '1c2022';
+
+    let studentRole = member.guild.roles.cache.find(
+        (role) => role.name === cuatrimestre
+    )!;
+
+    if (member.roles.cache.find((role) => role.name === cuatrimestre)) {
+        await interaction.editReply(
+            'Ya tenías el rol de grupo asignado!\n*Si es el equivocado, ponete en contacto con un docente para que vea tu situación.*'
+        );
+        return;
+    }
+
+    await member.roles.add(studentRole);
+
+    await interaction.editReply(
+        'Validación exitosa!, ya deberías poder ver más canales. \n*Si no es el caso contrario contactate con un docente.*'
+    );
+};
+
+export const data = new SlashCommandBuilder()
+    .setName('pedir_rol_alumno')
+    .setDescription(
+        'Verifica tus datos y te asigna permisos de alumno si existis en nuestra planilla.'
+    )
+    .addStringOption((option) =>
+        option.setName('email').setDescription('email').setRequired(true)
+    )
+    .addStringOption((option) =>
+        option.setName('padrón').setDescription('padron').setRequired(true)
+    );

--- a/src/commands/RequestDiscordAccessCommand.ts
+++ b/src/commands/RequestDiscordAccessCommand.ts
@@ -20,9 +20,9 @@ function padronIsValid(padron: string) {
 }
 
 function studentIsValid(email: string, padron: string): boolean {
-    return (students as any[]).some((student) => (
-        student.includes(email) && student.includes(padron)
-    ));
+    return (students as any[]).some(
+        (student) => student.includes(email) && student.includes(padron)
+    );
 }
 
 export const execute: ExecuteFunction = async (

--- a/submodules/repositories/events_repository.py
+++ b/submodules/repositories/events_repository.py
@@ -18,6 +18,9 @@ class EventsRepository:
         request = self.events().list(calendarId=self.__calendar_id, timeMin=now,
                                      maxResults=1, singleEvents=True, orderBy='startTime')
         response = request.execute()
-        print('Got it!')
+
+        if len(response.get('items', [])) == 0:
+            print('No upcoming events found. CHECK IF THE CALENDAR ID IS CORRECT')
+            return {}
 
         return response.get('items', [])[0]


### PR DESCRIPTION
# Motivation

Students arrive to the server not having any roles. The fact of not having roles only allows you to see the readme channel and the general query channel. We need a way (or command in this case) to allow students to "register" or request the student's role in order to interact with the other channel

# Proposal

A command named `pedir_rol_alumno` that needs to parameters `email` & `padron` that tries to match this parameters with a student's list that is scrapped from our internal google spread sheet.