### PR TITLE
[Feature] Cambio de formato en el que se guarda la fecha del log de una ayuda de discord

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -216,10 +216,7 @@ class Bot extends Client {
         );
         child_process.spawn('python3', [
             `./scripts/help_logger.py`,
-            Bot.dateFromISO(
-                creationDate.toISOString(),
-                'America/Argentina/Buenos_Aires'
-            ),
+            creationDate.toISOString(),
             creator,
             end,
             helper,


### PR DESCRIPTION
Fix #55 

## Motivación

Las fechas se estaban guardando en un formato que no era conveniente para el posterior análisis.

